### PR TITLE
chore: fix small typo in README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ dub run [-- options]
 ```
 If you already built the project, you can also run it directly:
 ```
-./generated/bayernfahrplan [options]
+./bayernfahrplan [options]
 ```
 See configuration for a list of available options.
 


### PR DESCRIPTION
Fixes a small typo in `README.md` file.
