### PR TITLE
Include all files in the bayernfahrplan package

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,6 @@
+ignore:
+- "*/package.d"
+
 coverage:
   notify:
     gitter:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,6 +1,3 @@
-ignore:
-- "*/package.d"
-
 coverage:
   notify:
     gitter:

--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,5 @@ docs/
 *.lst
 
 # bayernfahrplan
-bayernfahrplan*
+/bayernfahrplan*
 replacement.txt

--- a/source/bayernfahrplan/app.d
+++ b/source/bayernfahrplan/app.d
@@ -1,4 +1,7 @@
-import fahrplanparser;
+module bayernfahrplan.app;
+
+import bayernfahrplan.fahrplanparser : parsedFahrplan;
+import bayernfahrplan.fahrplanparser.substitution : loadSubstitutionFile;
 
 import requests : getContent;
 

--- a/source/bayernfahrplan/app.d
+++ b/source/bayernfahrplan/app.d
@@ -1,12 +1,12 @@
 module bayernfahrplan.app;
 
-import bayernfahrplan.fahrplanparser : parsedFahrplan;
+import bayernfahrplan.fahrplanparser.parser : parsedFahrplan;
 import bayernfahrplan.fahrplanparser.substitution : loadSubstitutionFile;
 
 import requests : getContent;
 
 import std.array : array, replace;
-import std.datetime : Clock;
+import std.datetime.systime : Clock;
 import std.file : exists, isFile;
 import std.format : format;
 import std.getopt : defaultGetoptPrinter, getopt;

--- a/source/bayernfahrplan/fahrplanparser/exceptions.d
+++ b/source/bayernfahrplan/fahrplanparser/exceptions.d
@@ -1,4 +1,4 @@
-module fahrplanparser.exceptions;
+module bayernfahrplan.fahrplanparser.exceptions;
 
 private:
 import std.conv : to;

--- a/source/bayernfahrplan/fahrplanparser/package.d
+++ b/source/bayernfahrplan/fahrplanparser/package.d
@@ -1,0 +1,3 @@
+module bayernfahrplan.fahrplanparser;
+
+public import bayernfahrplan.fahrplanparser.parser : parsedFahrplan;

--- a/source/bayernfahrplan/fahrplanparser/package.d
+++ b/source/bayernfahrplan/fahrplanparser/package.d
@@ -1,3 +1,4 @@
 module bayernfahrplan.fahrplanparser;
 
-public import bayernfahrplan.fahrplanparser.parser : parsedFahrplan;
+public import bayernfahrplan.fahrplanparser.parser;
+public import bayernfahrplan.fahrplanparser.substitution;

--- a/source/bayernfahrplan/fahrplanparser/parser.d
+++ b/source/bayernfahrplan/fahrplanparser/parser.d
@@ -1,4 +1,4 @@
-module fahrplanparser.parser;
+module bayernfahrplan.fahrplanparser.parser;
 
 import dxml.dom : DOMEntity, parseDOM;
 
@@ -9,14 +9,15 @@ import std.conv : to;
 import std.datetime : hours, minutes;
 import std.datetime.date : Date, DateTime, DateTimeException, TimeOfDay;
 
-import fahrplanparser.exceptions : CouldNotFindNodeWithContentException,
+import bayernfahrplan.fahrplanparser.exceptions : CouldNotFindNodeWithContentException,
     UnexpectedValueException;
-import fahrplanparser.xmlconstants;
-import fahrplanparser.xmlutils : getSubnodesWithName, getAllSubnodes;
+import bayernfahrplan.fahrplanparser.xmlconstants;
+import bayernfahrplan.fahrplanparser.xmlutils : getSubnodesWithName,
+    getAllSubnodes;
 
-private:
+    private:
 
-const DateTime currentDateTime;
+    const DateTime currentDateTime;
 
 static this()
 {
@@ -45,7 +46,7 @@ auto parsedFahrplan(string data, int reachabilityThreshold = 0)
 
     import dxml.util : normalize;
 
-    import fahrplanparser.substitution : substitute;
+    import bayernfahrplan.fahrplanparser.substitution : substitute;
 
     return data.parseDOM.getSubnodesWithName!efaNodeName
         .getSubnodesWithName!departuresNodeName

--- a/source/bayernfahrplan/fahrplanparser/parser.d
+++ b/source/bayernfahrplan/fahrplanparser/parser.d
@@ -4,7 +4,7 @@ import dxml.dom : DOMEntity, parseDOM;
 
 import fluent.asserts : should;
 
-import std.algorithm : filter;
+import std.algorithm.iteration : filter;
 import std.conv : to;
 import std.datetime : hours, minutes;
 import std.datetime.date : Date, DateTime, DateTimeException, TimeOfDay;
@@ -663,7 +663,7 @@ do
     auto realtimeNodes = dp.getSubnodesWithName!useRealTimeNodeName;
     if (realtimeNodes.empty)
     {
-        return minutes(0);
+        return 0.minutes;
     }
     auto useRealTimeNodes = realtimeNodes.getAllSubnodes;
     if (useRealTimeNodes.empty)
@@ -968,9 +968,7 @@ do
 bool isReachable(DOMEntity!string dp, in int reachabilityThreshold,
         in DateTime currentTime = currentDateTime)
 {
-    import std.datetime : minutes;
-
-    auto reachingDuration = minutes(reachabilityThreshold);
+    auto reachingDuration = reachabilityThreshold.minutes;
 
     auto departureDateTime = DateTime(dp.departureDate, dp.departureTime) + dp.delay;
 

--- a/source/bayernfahrplan/fahrplanparser/substitution.d
+++ b/source/bayernfahrplan/fahrplanparser/substitution.d
@@ -1,4 +1,4 @@
-module fahrplanparser.substitution;
+module bayernfahrplan.fahrplanparser.substitution;
 
 import fluent.asserts;
 

--- a/source/bayernfahrplan/fahrplanparser/substitution.d
+++ b/source/bayernfahrplan/fahrplanparser/substitution.d
@@ -1,6 +1,6 @@
 module bayernfahrplan.fahrplanparser.substitution;
 
-import fluent.asserts;
+import fluent.asserts : should;
 
 import std.file : slurp;
 import std.meta : AliasSeq;

--- a/source/bayernfahrplan/fahrplanparser/xmlconstants.d
+++ b/source/bayernfahrplan/fahrplanparser/xmlconstants.d
@@ -1,4 +1,4 @@
-module fahrplanparser.xmlconstants;
+module bayernfahrplan.fahrplanparser.xmlconstants;
 
 package:
 enum efaNodeName = "efa";

--- a/source/bayernfahrplan/fahrplanparser/xmlutils.d
+++ b/source/bayernfahrplan/fahrplanparser/xmlutils.d
@@ -1,4 +1,4 @@
-module fahrplanparser.xmlutils;
+module bayernfahrplan.fahrplanparser.xmlutils;
 
 private:
 import dxml.dom : DOMEntity, parseDOM;
@@ -7,7 +7,7 @@ import std.algorithm.iteration : filter;
 
 import std.array : empty, front, popFront;
 
-import fahrplanparser.exceptions : CouldNotFindNodeWithContentException;
+import bayernfahrplan.fahrplanparser.exceptions : CouldNotFindNodeWithContentException;
 
 import std.range.primitives : isInputRange, ElementType;
 

--- a/source/fahrplanparser/package.d
+++ b/source/fahrplanparser/package.d
@@ -1,4 +1,0 @@
-module fahrplanparser;
-
-public import fahrplanparser.parser : parsedFahrplan;
-public import fahrplanparser.substitution : loadSubstitutionFile;


### PR DESCRIPTION
This includes the following changes:
 - move all source files to the `bayernfahrplan` package
 - exclude `package.d` file from codecov reports
